### PR TITLE
refactor: rename ChatWidget to ChatPage and update routing

### DIFF
--- a/apps/shell/src/app/App.tsx
+++ b/apps/shell/src/app/App.tsx
@@ -4,7 +4,7 @@ import { DashboardPage, LoginPage, RegisterPage } from "@/pages";
 import { RemoteErrorBoundary } from "@/shared/ui";
 import { RequireAuth, RequireGuest, UnknownPathRedirect } from "./routing";
 
-const ChatWidget = lazy(() => import("chatApp/Widget"));
+const ChatPage = lazy(() => import("chatApp/ChatPage"));
 const TeamsPage = lazy(() => import("coachingApp/TeamsPage"));
 const BoardsPage = lazy(() => import("coachingApp/BoardsPage"));
 const WorkoutPlansPage = lazy(() => import("coachingApp/WorkoutPlansPage"));
@@ -35,7 +35,7 @@ const remoteRoutes: RemoteRouteConfig[] = [
     path: "/chat",
     title: "Chat",
     loadingText: "Loading chat...",
-    element: <ChatWidget />,
+    element: <ChatPage />,
   },
   {
     path: "/teams",

--- a/apps/shell/src/vite-env.d.ts
+++ b/apps/shell/src/vite-env.d.ts
@@ -10,10 +10,10 @@ interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
 
-declare module "chatApp/Widget" {
+declare module "chatApp/ChatPage" {
   import type { ComponentType } from "react";
-  const ChatWidget: ComponentType;
-  export default ChatWidget;
+  const ChatPage: ComponentType;
+  export default ChatPage;
 }
 
 declare module "coachingApp/TeamsPage" {


### PR DESCRIPTION
- Changed the module declaration from "chatApp/Widget" to "chatApp/ChatPage" for better clarity.
- Updated the App component to lazy load ChatPage instead of ChatWidget, reflecting the new naming convention.
- Adjusted routing configuration to utilize the new ChatPage component in the chat route.