### PR TITLE
feat: add host auth bridge and harden auth guard behavior

### DIFF
--- a/apps/shell/src/app/providers/QueryProvider.tsx
+++ b/apps/shell/src/app/providers/QueryProvider.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
+import { initAuthBridge } from "@/shared/auth/authBridge";
 
 function createQueryClient() {
   return new QueryClient({
@@ -22,5 +23,11 @@ interface QueryProviderProps {
 
 export function QueryProvider({ children }: QueryProviderProps) {
   const [client] = useState(createQueryClient);
+
+  useEffect(() => {
+    const cleanup = initAuthBridge(client);
+    return cleanup;
+  }, [client]);
+
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }

--- a/apps/shell/src/app/routing/routeGuards.tsx
+++ b/apps/shell/src/app/routing/routeGuards.tsx
@@ -9,9 +9,13 @@ import { ShellLayout } from "@/widgets/layout";
 import { RouteLoadingFallback } from "./RouteLoadingFallback";
 
 export function RequireAuth({ children }: { children: ReactNode }) {
-  const { data: user, isPending } = useSessionQuery();
+  const { data: user, isPending, isError } = useSessionQuery();
 
   if (isPending) {
+    return <RouteLoadingFallback />;
+  }
+
+  if (isError) {
     return <RouteLoadingFallback />;
   }
 
@@ -23,9 +27,13 @@ export function RequireAuth({ children }: { children: ReactNode }) {
 }
 
 export function RequireGuest({ children }: { children: ReactNode }) {
-  const { data: user, isPending } = useSessionQuery();
+  const { data: user, isPending, isError } = useSessionQuery();
 
   if (isPending) {
+    return <RouteLoadingFallback />;
+  }
+
+  if (isError) {
     return <RouteLoadingFallback />;
   }
 
@@ -37,9 +45,13 @@ export function RequireGuest({ children }: { children: ReactNode }) {
 }
 
 export function UnknownPathRedirect() {
-  const { data: user, isPending } = useSessionQuery();
+  const { data: user, isPending, isError } = useSessionQuery();
 
   if (isPending) {
+    return <RouteLoadingFallback />;
+  }
+
+  if (isError) {
     return <RouteLoadingFallback />;
   }
 

--- a/apps/shell/src/features/auth/api/authApi.ts
+++ b/apps/shell/src/features/auth/api/authApi.ts
@@ -129,7 +129,7 @@ export function useLogoutMutation() {
 
   return useAuthLogout({
     mutation: {
-      onSettled: () => {
+      onSuccess: () => {
         clearSessionCache(queryClient);
       },
     },

--- a/apps/shell/src/features/auth/api/authApi.ts
+++ b/apps/shell/src/features/auth/api/authApi.ts
@@ -129,7 +129,7 @@ export function useLogoutMutation() {
 
   return useAuthLogout({
     mutation: {
-      onSuccess: () => {
+      onSettled: () => {
         clearSessionCache(queryClient);
       },
     },

--- a/apps/shell/src/shared/auth/authBridge.ts
+++ b/apps/shell/src/shared/auth/authBridge.ts
@@ -1,0 +1,121 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { User } from "@/entities/user/types";
+import { authQueryKeys } from "@/features/auth/api";
+import { authLogout } from "@/shared/api/generated/api";
+
+export type AuthUser = Pick<User, "id" | "email" | "fullName" | "role">;
+
+export type AuthSession = {
+  isAuthenticated: boolean;
+  user: AuthUser | null;
+};
+
+export type AuthBridge = {
+  getSession: () => AuthSession;
+  subscribe: (listener: (session: AuthSession) => void) => () => void;
+  logout: () => Promise<void>;
+};
+
+const listeners = new Set<(session: AuthSession) => void>();
+
+let queryClientRef: QueryClient | null = null;
+let unsubscribeQueryCache: (() => void) | null = null;
+let lastSession: AuthSession = { isAuthenticated: false, user: null };
+
+function toAuthSession(user: User | null | undefined): AuthSession {
+  if (!user) {
+    return { isAuthenticated: false, user: null };
+  }
+
+  return {
+    isAuthenticated: true,
+    user: {
+      id: user.id,
+      email: user.email,
+      fullName: user.fullName,
+      role: user.role,
+    },
+  };
+}
+
+function readSessionFromCache(queryClient: QueryClient): AuthSession {
+  const user = queryClient.getQueryData<User | null>(authQueryKeys.session());
+  return toAuthSession(user);
+}
+
+function notify(session: AuthSession) {
+  listeners.forEach((listener) => {
+    listener(session);
+  });
+}
+
+function syncAndNotify(session: AuthSession) {
+  if (
+    lastSession.isAuthenticated === session.isAuthenticated &&
+    lastSession.user?.id === session.user?.id &&
+    lastSession.user?.email === session.user?.email &&
+    lastSession.user?.fullName === session.user?.fullName &&
+    lastSession.user?.role === session.user?.role
+  ) {
+    return;
+  }
+
+  lastSession = session;
+  notify(session);
+}
+
+export function initAuthBridge(queryClient: QueryClient) {
+  queryClientRef = queryClient;
+  syncAndNotify(readSessionFromCache(queryClient));
+
+  if (unsubscribeQueryCache) {
+    unsubscribeQueryCache();
+  }
+
+  const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+    if (event.type !== "updated") {
+      return;
+    }
+
+    const key = event.query.queryKey;
+    if (key[0] !== "auth" || key[1] !== "session") {
+      return;
+    }
+
+    syncAndNotify(readSessionFromCache(queryClient));
+  });
+
+  unsubscribeQueryCache = unsubscribe;
+
+  return () => {
+    if (unsubscribeQueryCache === unsubscribe) {
+      unsubscribeQueryCache = null;
+    }
+    unsubscribe();
+  };
+}
+
+export const authBridge: AuthBridge = {
+  getSession: () => {
+    if (queryClientRef) {
+      lastSession = readSessionFromCache(queryClientRef);
+    }
+    return lastSession;
+  },
+  subscribe: (listener) => {
+    listeners.add(listener);
+    listener(authBridge.getSession());
+
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  logout: async () => {
+    if (!queryClientRef) {
+      throw new Error("Auth bridge is not initialized");
+    }
+
+    await authLogout();
+    queryClientRef.setQueryData(authQueryKeys.session(), null);
+  },
+};

--- a/apps/shell/src/shared/auth/authBridge.ts
+++ b/apps/shell/src/shared/auth/authBridge.ts
@@ -115,7 +115,10 @@ export const authBridge: AuthBridge = {
       throw new Error("Auth bridge is not initialized");
     }
 
-    await authLogout();
-    queryClientRef.setQueryData(authQueryKeys.session(), null);
+    try {
+      await authLogout();
+    } finally {
+      queryClientRef.setQueryData(authQueryKeys.session(), null);
+    }
   },
 };

--- a/apps/shell/vite.config.ts
+++ b/apps/shell/vite.config.ts
@@ -20,6 +20,9 @@ export default defineConfig(({ mode }) => {
       react(),
       federation({
         name: "shell",
+        exposes: {
+          "./authBridge": "./src/shared/auth/authBridge.ts",
+        },
         remotes: {
           chatApp: chatRemoteUrl,
           coachingApp: coachingRemoteUrl,
@@ -31,6 +34,16 @@ export default defineConfig(({ mode }) => {
       alias: {
         "@": path.resolve(__dirname, "./src"),
       },
+    },
+    server: {
+      port: 5173,
+      strictPort: true,
+      cors: true,
+    },
+    preview: {
+      port: 5173,
+      strictPort: true,
+      cors: true,
     },
     build: {
       target: "esnext",


### PR DESCRIPTION
Expose a typed auth bridge for remotes backed by host session cache, and prevent false auth state transitions by clearing logout state only on success and avoiding login redirects on transient session errors.
