### PR TITLE
chore(shell): default MFE remotes to deployed Vercel URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 VITE_API_URL=http://localhost:3000
 
-# TODO(mf): update both remote URLs to deployed remoteEntry endpoints for shared environments.
-VITE_CHAT_REMOTE_URL=http://localhost:4174/assets/remoteEntry.js
-VITE_COACHING_REMOTE_URL=http://localhost:4175/assets/remoteEntry.js
+# Module federation (see apps/shell/vite.config.ts). Defaults: deployed MFEs (same as vercel.json).
+VITE_CHAT_REMOTE_URL=https://promentor-chat.vercel.app/assets/remoteEntry.js
+VITE_COACHING_REMOTE_URL=https://promentor-coaching.vercel.app/assets/remoteEntry.js
+
+# Local preview (`pnpm mf:serve` in chat/coaching repos):
+# VITE_CHAT_REMOTE_URL=http://localhost:4174/assets/remoteEntry.js
+# VITE_COACHING_REMOTE_URL=http://localhost:4175/assets/remoteEntry.js

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ pnpm dev:web
 - Shell (Vercel): [https://promentor-alpha.vercel.app](https://promentor-alpha.vercel.app)
 - API (Railway): [https://promentor-production.up.railway.app](https://promentor-production.up.railway.app)
 
+**Module federation remotes (production):**
+
+- Chat: [promentor-chat.vercel.app](https://promentor-chat.vercel.app) → `remoteEntry` at `https://promentor-chat.vercel.app/assets/remoteEntry.js`
+- Coaching: [promentor-coaching.vercel.app](https://promentor-coaching.vercel.app) → `https://promentor-coaching.vercel.app/assets/remoteEntry.js`
+
+The shell Vite build reads `VITE_CHAT_REMOTE_URL` and `VITE_COACHING_REMOTE_URL`. They are set in [`vercel.json`](vercel.json) for the shell deployment so the host loads these remotes by default. Override in the Vercel project **Environment Variables** if needed.
+
 ## Env
 
 - Shell: `.env.example` → `apps/shell/.env` (`VITE_*` for browser).

--- a/apps/shell/.env.example
+++ b/apps/shell/.env.example
@@ -1,2 +1,11 @@
 # Required for API calls and Google OAuth (/auth/google is on the API, not the shell).
 VITE_API_URL=http://localhost:3000
+
+# Module federation — full URLs to remoteEntry.js (see vite.config.ts `remotes`).
+# Defaults match vercel.json: deployed MFEs. Override for local chat/coaching preview.
+VITE_CHAT_REMOTE_URL=https://promentor-chat.vercel.app/assets/remoteEntry.js
+VITE_COACHING_REMOTE_URL=https://promentor-coaching.vercel.app/assets/remoteEntry.js
+
+# Local preview (run `pnpm mf:serve` in promentor-chat / promentor-coaching):
+# VITE_CHAT_REMOTE_URL=http://localhost:4174/assets/remoteEntry.js
+# VITE_COACHING_REMOTE_URL=http://localhost:4175/assets/remoteEntry.js

--- a/apps/shell/vite.config.ts
+++ b/apps/shell/vite.config.ts
@@ -7,10 +7,11 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
 
   const chatRemoteUrl =
-    env.VITE_CHAT_REMOTE_URL || "http://localhost:4174/assets/remoteEntry.js";
+    env.VITE_CHAT_REMOTE_URL ||
+    "https://promentor-chat.vercel.app/assets/remoteEntry.js";
   const coachingRemoteUrl =
     env.VITE_COACHING_REMOTE_URL ||
-    "http://localhost:4175/assets/remoteEntry.js";
+    "https://promentor-coaching.vercel.app/assets/remoteEntry.js";
 
   return {
     optimizeDeps: {

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,9 @@
   "installCommand": "pnpm install",
   "buildCommand": "pnpm exec turbo build --filter=shell",
   "outputDirectory": "apps/shell/dist",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "env": {
+    "VITE_CHAT_REMOTE_URL": "https://promentor-chat.vercel.app/assets/remoteEntry.js",
+    "VITE_COACHING_REMOTE_URL": "https://promentor-coaching.vercel.app/assets/remoteEntry.js"
+  }
 }


### PR DESCRIPTION
Align .env.example, vite fallbacks, and vercel.json with chat/coaching production remoteEntry endpoints; document in README. Local mf:serve URLs remain as commented overrides.

