### PR TITLE
feat(api): run prisma migrate deploy on startup in production

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,8 @@
     "test": "jest --config jest.config.json --runInBand",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.e2e.json",
     "prisma:generate": "prisma generate",
-    "prisma:migrate:dev": "prisma migrate dev"
+    "prisma:migrate:dev": "prisma migrate dev",
+    "prisma:migrate:deploy": "prisma migrate deploy"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.15",

--- a/apps/api/src/bootstrap/run-prisma-migrate.ts
+++ b/apps/api/src/bootstrap/run-prisma-migrate.ts
@@ -1,0 +1,17 @@
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+
+export function runPrismaMigrateDeployIfProduction(): void {
+  if (process.env.NODE_ENV !== "production") {
+    return;
+  }
+  if (process.env.SKIP_PRISMA_MIGRATE === "true") {
+    return;
+  }
+  const apiRoot = join(__dirname, "..", "..");
+  execSync("pnpm exec prisma migrate deploy", {
+    cwd: apiRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,9 +2,12 @@ import "dotenv/config";
 import { NestFactory } from "@nestjs/core";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { applyHttpAppSetup, applyTrustProxy } from "./bootstrap/http-app-setup";
+import { runPrismaMigrateDeployIfProduction } from "./bootstrap/run-prisma-migrate";
 import { AppModule } from "./app.module";
 
 async function bootstrap() {
+  runPrismaMigrateDeployIfProduction();
+
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   applyTrustProxy(app);


### PR DESCRIPTION
Run migrations before Nest boot when NODE_ENV is production; skip in development. Optional SKIP_PRISMA_MIGRATE=true to disable. Add prisma:migrate:deploy script for manual runs.

