### PR TITLE
fix(api): use camelCase columns in room_members lastReadAt migration

### DIFF
--- a/apps/api/prisma/migrations/20260413140000_room_member_last_read_at/migration.sql
+++ b/apps/api/prisma/migrations/20260413140000_room_member_last_read_at/migration.sql
@@ -1,3 +1,3 @@
-ALTER TABLE "room_members" ADD COLUMN "last_read_at" TIMESTAMP(3);
+ALTER TABLE "room_members" ADD COLUMN "lastReadAt" TIMESTAMP(3);
 
-UPDATE "room_members" SET "last_read_at" = "joined_at" WHERE "last_read_at" IS NULL;
+UPDATE "room_members" SET "lastReadAt" = "joinedAt" WHERE "lastReadAt" IS NULL;


### PR DESCRIPTION
PostgreSQL columns are joinedAt/lastReadAt per Prisma; snake_case joined_at/last_read_at caused migration to fail (42703).

