### PR TITLE
refactor(chat): remove ChatProfilePage from routing and type declarat…

### DIFF
--- a/apps/shell/src/app/App.tsx
+++ b/apps/shell/src/app/App.tsx
@@ -6,7 +6,6 @@ import { RequireAuth, RequireGuest, UnknownPathRedirect } from "./routing";
 
 const ChatEmptyPage = lazy(() => import("chatApp/ChatEmptyPage"));
 const ChatCreateGroupPage = lazy(() => import("chatApp/ChatCreateGroupPage"));
-const ChatProfilePage = lazy(() => import("chatApp/ChatProfilePage"));
 const ChatConversationPage = lazy(() => import("chatApp/ChatConversationPage"));
 const ChatSidebar = lazy(() => import("chatApp/ChatSidebar"));
 
@@ -53,18 +52,6 @@ const remoteRoutes: RemoteRouteConfig[] = [
     title: "Create Group",
     loadingText: "Loading create group...",
     element: <ChatCreateGroupPage />,
-  },
-  {
-    path: "/chat/profile",
-    title: "Profile",
-    loadingText: "Loading profile...",
-    element: <ChatProfilePage />,
-  },
-  {
-    path: "/chat/profile/:slug",
-    title: "Profile",
-    loadingText: "Loading profile...",
-    element: <ChatProfilePage />,
   },
   {
     path: "/chat/:chatId",

--- a/apps/shell/src/vite-env.d.ts
+++ b/apps/shell/src/vite-env.d.ts
@@ -28,12 +28,6 @@ declare module "chatApp/ChatCreateGroupPage" {
   export default ChatCreateGroupPage;
 }
 
-declare module "chatApp/ChatProfilePage" {
-  import type { ComponentType } from "react";
-  const ChatProfilePage: ComponentType;
-  export default ChatProfilePage;
-}
-
 declare module "chatApp/ChatSidebar" {
   import type { ComponentType } from "react";
   const ChatSidebar: ComponentType;


### PR DESCRIPTION
…ions

- Deleted the ChatProfilePage import and its associated routes from the App component.
- Updated the vite-env.d.ts file to remove the ChatProfilePage module declaration, streamlining the chat application structure.