### PR TITLE
feat(api): enhance body parsing and add toast notifications

### DIFF
--- a/apps/api/jest.config.json
+++ b/apps/api/jest.config.json
@@ -2,7 +2,10 @@
   "rootDir": ".",
   "testEnvironment": "node",
   "moduleFileExtensions": ["js", "json", "ts"],
-  "testRegex": ".*\\.e2e-spec\\.ts$",
+  "testMatch": [
+    "<rootDir>/test/**/*.e2e-spec.ts",
+    "<rootDir>/src/**/*.spec.ts"
+  ],
   "transform": {
     "^.+\\.(t|j)s$": [
       "ts-jest",

--- a/apps/api/src/bootstrap/http-app-setup.ts
+++ b/apps/api/src/bootstrap/http-app-setup.ts
@@ -2,10 +2,10 @@ import { BadRequestException, ValidationPipe } from "@nestjs/common";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import cookieParser from "cookie-parser";
 import { json, urlencoded } from "express";
-
-const JSON_BODY_LIMIT = "6mb";
 import { ApiExceptionFilter } from "../common/http/api-exception.filter";
 import { createCorsOptions } from "../config/cors.config";
+
+const JSON_BODY_LIMIT = "6mb";
 
 export function applyTrustProxy(app: NestExpressApplication): void {
   const raw = process.env.TRUST_PROXY?.trim();

--- a/apps/api/src/bootstrap/http-app-setup.ts
+++ b/apps/api/src/bootstrap/http-app-setup.ts
@@ -1,6 +1,9 @@
 import { BadRequestException, ValidationPipe } from "@nestjs/common";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import cookieParser from "cookie-parser";
+import { json, urlencoded } from "express";
+
+const JSON_BODY_LIMIT = "6mb";
 import { ApiExceptionFilter } from "../common/http/api-exception.filter";
 import { createCorsOptions } from "../config/cors.config";
 
@@ -20,6 +23,8 @@ export function applyTrustProxy(app: NestExpressApplication): void {
 }
 
 export function applyHttpAppSetup(app: NestExpressApplication): void {
+  app.use(json({ limit: JSON_BODY_LIMIT }));
+  app.use(urlencoded({ extended: true, limit: JSON_BODY_LIMIT }));
   app.use(cookieParser());
   app.enableCors(createCorsOptions());
   app.useGlobalFilters(new ApiExceptionFilter());

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,7 +8,9 @@ import { AppModule } from "./app.module";
 async function bootstrap() {
   runPrismaMigrateDeployIfProduction();
 
-  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    bodyParser: false,
+  });
 
   applyTrustProxy(app);
   applyHttpAppSetup(app);

--- a/apps/api/src/modules/users/dto/update-my-user.dto.ts
+++ b/apps/api/src/modules/users/dto/update-my-user.dto.ts
@@ -1,11 +1,6 @@
 import { Transform } from "class-transformer";
-import {
-  IsOptional,
-  IsString,
-  IsUrl,
-  MaxLength,
-  MinLength,
-} from "class-validator";
+import { IsOptional, IsString, MaxLength, MinLength } from "class-validator";
+import { IsDeviceAvatarDataUrl } from "./validators/avatar-url.validator";
 
 function trimString(value: unknown): unknown {
   return typeof value === "string" ? value.trim() : value;
@@ -30,8 +25,8 @@ export class UpdateMyUserDto {
 
   @IsOptional()
   @Transform(({ value }) => trimOrNull(value))
-  @IsUrl({ require_protocol: true })
-  @MaxLength(2048)
+  @IsDeviceAvatarDataUrl()
+  @MaxLength(5_000_000)
   avatarUrl?: string | null;
 
   @IsOptional()

--- a/apps/api/src/modules/users/dto/update-my-user.dto.ts
+++ b/apps/api/src/modules/users/dto/update-my-user.dto.ts
@@ -1,6 +1,9 @@
 import { Transform } from "class-transformer";
 import { IsOptional, IsString, MaxLength, MinLength } from "class-validator";
-import { IsDeviceAvatarDataUrl } from "./validators/avatar-url.validator";
+import {
+  IsDeviceAvatarDataUrl,
+  MAX_AVATAR_VALUE_LENGTH,
+} from "./validators/avatar-url.validator";
 
 function trimString(value: unknown): unknown {
   return typeof value === "string" ? value.trim() : value;
@@ -26,7 +29,7 @@ export class UpdateMyUserDto {
   @IsOptional()
   @Transform(({ value }) => trimOrNull(value))
   @IsDeviceAvatarDataUrl()
-  @MaxLength(5_000_000)
+  @MaxLength(MAX_AVATAR_VALUE_LENGTH)
   avatarUrl?: string | null;
 
   @IsOptional()

--- a/apps/api/src/modules/users/dto/validators/avatar-url.validator.spec.ts
+++ b/apps/api/src/modules/users/dto/validators/avatar-url.validator.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@jest/globals";
+import { isDeviceAvatarDataUrl } from "./avatar-url.validator";
+
+const DATA_PNG_PREFIX = "data:image/png;base64,";
+
+const FULL_BASE64_PAYLOAD_SCAN_BYTES = 256 * 1024;
+
+function coreBase64Body(length: number): string {
+  return "A".repeat(length);
+}
+
+function dataUrlWithPayloadLength(payloadLength: number): string {
+  return DATA_PNG_PREFIX + coreBase64Body(payloadLength);
+}
+
+describe("isDeviceAvatarDataUrl — large payload / sampling branch", () => {
+  it("uses full scan at exactly FULL_BASE64_PAYLOAD_SCAN_BYTES", () => {
+    const url = dataUrlWithPayloadLength(FULL_BASE64_PAYLOAD_SCAN_BYTES);
+    expect(isDeviceAvatarDataUrl(url)).toBe(true);
+  });
+
+  it("uses sampling when payload is one byte above the full-scan limit", () => {
+    const url = dataUrlWithPayloadLength(FULL_BASE64_PAYLOAD_SCAN_BYTES + 1);
+    expect(isDeviceAvatarDataUrl(url)).toBe(true);
+  });
+
+  it("accepts a valid data URL well above 256 KiB (sampling regression)", () => {
+    const url = dataUrlWithPayloadLength(
+      FULL_BASE64_PAYLOAD_SCAN_BYTES + 64 * 1024,
+    );
+    expect(isDeviceAvatarDataUrl(url)).toBe(true);
+  });
+
+  it("rejects a large payload with a non-base64 character in the head chunk", () => {
+    const payload = "!" + coreBase64Body(FULL_BASE64_PAYLOAD_SCAN_BYTES + 4096);
+    expect(isDeviceAvatarDataUrl(DATA_PNG_PREFIX + payload)).toBe(false);
+  });
+
+  it("rejects a large payload when the tail fails strict base64 body pattern", () => {
+    const len = FULL_BASE64_PAYLOAD_SCAN_BYTES + 12_000;
+    const payload = coreBase64Body(len - 1) + "!";
+    expect(isDeviceAvatarDataUrl(DATA_PNG_PREFIX + payload)).toBe(false);
+  });
+
+  it("rejects a large payload with a non-base64 character in an interior sampled slice", () => {
+    const len = FULL_BASE64_PAYLOAD_SCAN_BYTES + 20_000;
+    const before = coreBase64Body(8200);
+    const after = coreBase64Body(len - before.length - 1);
+    const payload = `${before}!${after}`;
+    expect(isDeviceAvatarDataUrl(DATA_PNG_PREFIX + payload)).toBe(false);
+  });
+});

--- a/apps/api/src/modules/users/dto/validators/avatar-url.validator.ts
+++ b/apps/api/src/modules/users/dto/validators/avatar-url.validator.ts
@@ -1,8 +1,75 @@
 import { ValidateBy, type ValidationOptions } from "class-validator";
 
-const MAX_AVATAR_VALUE_LENGTH = 5_000_000;
+export const MAX_AVATAR_VALUE_LENGTH = 5_000_000;
 
 const DATA_IMAGE_PREFIX = /^data:image\/(png|jpeg|jpg|gif|webp);base64,/i;
+
+const FULL_BASE64_PAYLOAD_SCAN_BYTES = 256 * 1024;
+
+const LARGE_PAYLOAD_SAMPLE_CHUNK = 8192;
+const LARGE_PAYLOAD_INTERIOR_SLICES = 8;
+const LARGE_PAYLOAD_INTERIOR_SLICE_LEN = 512;
+
+const BASE64_BODY = /^[A-Za-z0-9+/]+=*$/;
+
+function isBase64BodyChar(code: number): boolean {
+  return (
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    (code >= 48 && code <= 57) ||
+    code === 43 ||
+    code === 47
+  );
+}
+
+function segmentIsCoreBase64(
+  payload: string,
+  start: number,
+  end: number,
+): boolean {
+  for (let i = start; i < end; i++) {
+    if (!isBase64BodyChar(payload.charCodeAt(i))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function largePayloadLooksLikeBase64(payload: string): boolean {
+  const n = payload.length;
+  const headLen = Math.min(LARGE_PAYLOAD_SAMPLE_CHUNK, n);
+  if (!segmentIsCoreBase64(payload, 0, headLen)) {
+    return false;
+  }
+
+  const tailStart = Math.max(0, n - LARGE_PAYLOAD_SAMPLE_CHUNK);
+  if (!BASE64_BODY.test(payload.slice(tailStart))) {
+    return false;
+  }
+
+  const interiorEnd = tailStart;
+  const interiorSpan = interiorEnd - headLen;
+  if (interiorSpan <= LARGE_PAYLOAD_INTERIOR_SLICE_LEN) {
+    return true;
+  }
+
+  const step = Math.max(
+    1,
+    Math.floor(interiorSpan / (LARGE_PAYLOAD_INTERIOR_SLICES + 1)),
+  );
+  for (
+    let pos = headLen;
+    pos < interiorEnd - LARGE_PAYLOAD_INTERIOR_SLICE_LEN;
+    pos += step
+  ) {
+    const sliceEnd = pos + LARGE_PAYLOAD_INTERIOR_SLICE_LEN;
+    if (!segmentIsCoreBase64(payload, pos, sliceEnd)) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 function isDataImageBase64(value: string): boolean {
   const m = DATA_IMAGE_PREFIX.exec(value);
@@ -13,7 +80,10 @@ function isDataImageBase64(value: string): boolean {
   if (payload.length === 0) {
     return false;
   }
-  return /^[A-Za-z0-9+/]+=*$/.test(payload);
+  if (payload.length <= FULL_BASE64_PAYLOAD_SCAN_BYTES) {
+    return BASE64_BODY.test(payload);
+  }
+  return largePayloadLooksLikeBase64(payload);
 }
 
 export function isDeviceAvatarDataUrl(value: unknown): boolean {

--- a/apps/api/src/modules/users/dto/validators/avatar-url.validator.ts
+++ b/apps/api/src/modules/users/dto/validators/avatar-url.validator.ts
@@ -1,0 +1,45 @@
+import { ValidateBy, type ValidationOptions } from "class-validator";
+
+const MAX_AVATAR_VALUE_LENGTH = 5_000_000;
+
+const DATA_IMAGE_PREFIX = /^data:image\/(png|jpeg|jpg|gif|webp);base64,/i;
+
+function isDataImageBase64(value: string): boolean {
+  const m = DATA_IMAGE_PREFIX.exec(value);
+  if (!m || m.index !== 0) {
+    return false;
+  }
+  const payload = value.slice(m[0].length).replace(/\s/g, "");
+  if (payload.length === 0) {
+    return false;
+  }
+  return /^[A-Za-z0-9+/]+=*$/.test(payload);
+}
+
+export function isDeviceAvatarDataUrl(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  if (typeof value !== "string") {
+    return false;
+  }
+  if (value.length > MAX_AVATAR_VALUE_LENGTH) {
+    return false;
+  }
+  return isDataImageBase64(value);
+}
+
+export function IsDeviceAvatarDataUrl(validationOptions?: ValidationOptions) {
+  return ValidateBy(
+    {
+      name: "isDeviceAvatarDataUrl",
+      constraints: [],
+      validator: {
+        validate: (v: unknown): boolean => isDeviceAvatarDataUrl(v),
+        defaultMessage: () =>
+          "avatarUrl must be a PNG, JPEG, GIF, or WebP data URL from an uploaded image",
+      },
+    },
+    validationOptions,
+  );
+}

--- a/apps/api/test/chat.e2e-spec.ts
+++ b/apps/api/test/chat.e2e-spec.ts
@@ -59,7 +59,9 @@ describe("Chat backend (e2e)", () => {
       .useValue(fakePrisma)
       .compile();
 
-    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    app = moduleFixture.createNestApplication<NestExpressApplication>({
+      bodyParser: false,
+    });
     applyTrustProxy(app);
     applyHttpAppSetup(app);
 

--- a/apps/api/test/users.e2e-spec.ts
+++ b/apps/api/test/users.e2e-spec.ts
@@ -34,7 +34,9 @@ describe("Users search (e2e)", () => {
       .useValue(fakePrisma)
       .compile();
 
-    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    app = moduleFixture.createNestApplication<NestExpressApplication>({
+      bodyParser: false,
+    });
     applyTrustProxy(app);
     applyHttpAppSetup(app);
 
@@ -130,7 +132,9 @@ describe("GET /users pagination (e2e)", () => {
       .useValue(fakePrisma)
       .compile();
 
-    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    app = moduleFixture.createNestApplication<NestExpressApplication>({
+      bodyParser: false,
+    });
     applyTrustProxy(app);
     applyHttpAppSetup(app);
 
@@ -190,7 +194,9 @@ describe("Users me endpoints (e2e)", () => {
       .useValue(fakePrisma)
       .compile();
 
-    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    app = moduleFixture.createNestApplication<NestExpressApplication>({
+      bodyParser: false,
+    });
     applyTrustProxy(app);
     applyHttpAppSetup(app);
 
@@ -227,7 +233,7 @@ describe("Users me endpoints (e2e)", () => {
     );
     expect(res.body.errors).toEqual([
       "fullName must be longer than or equal to 3 characters",
-      "avatarUrl must be a URL address",
+      "avatarUrl must be a PNG, JPEG, GIF, or WebP data URL from an uploaded image",
     ]);
   });
 
@@ -316,7 +322,9 @@ describe("GET /users/search throttling (e2e)", () => {
       .useValue(fakePrisma)
       .compile();
 
-    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    app = moduleFixture.createNestApplication<NestExpressApplication>({
+      bodyParser: false,
+    });
     applyTrustProxy(app);
     applyHttpAppSetup(app);
 

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -19,7 +19,7 @@
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "types": ["node"],
+    "types": ["node", "jest"],
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
   },
   "include": ["src/**/*"],

--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -25,6 +25,7 @@
     "react-hook-form": "^7.72.0",
     "react-icons": "^5.6.0",
     "react-router-dom": "^7.13.2",
+    "react-toastify": "^11.0.5",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/apps/shell/src/app/providers/QueryProvider.tsx
+++ b/apps/shell/src/app/providers/QueryProvider.tsx
@@ -1,9 +1,45 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  MutationCache,
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import { type ReactNode, useEffect, useState } from "react";
+import { toast } from "react-toastify";
 import { initAuthBridge } from "@/shared/auth/authBridge";
+import { getErrorMessage } from "@/shared/api/getErrorMessage";
+
+const ERROR_TOAST_FALLBACK = "Something went wrong. Please try again." as const;
+
+function readErrorToastId(
+  meta: { notifyErrorToastId?: string } | undefined,
+): string | undefined {
+  const id = meta?.notifyErrorToastId;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
 
 function createQueryClient() {
   return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        const toastId = readErrorToastId(query.meta);
+        if (toastId) {
+          toast.error(getErrorMessage(error, ERROR_TOAST_FALLBACK), {
+            toastId,
+          });
+        }
+      },
+    }),
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        const toastId = readErrorToastId(mutation.meta);
+        if (toastId) {
+          toast.error(getErrorMessage(error, ERROR_TOAST_FALLBACK), {
+            toastId,
+          });
+        }
+      },
+    }),
     defaultOptions: {
       queries: {
         staleTime: 30_000,

--- a/apps/shell/src/app/providers/QueryProvider.tsx
+++ b/apps/shell/src/app/providers/QueryProvider.tsx
@@ -11,6 +11,7 @@ import { getErrorMessage } from "@/shared/api/getErrorMessage";
 
 const ERROR_TOAST_FALLBACK = "Something went wrong. Please try again." as const;
 
+/** Error toasts are opt-in: set `meta.notifyErrorToastId` on a query/mutation; no meta → no toast. */
 function readErrorToastId(
   meta: { notifyErrorToastId?: string } | undefined,
 ): string | undefined {

--- a/apps/shell/src/main.tsx
+++ b/apps/shell/src/main.tsx
@@ -2,8 +2,10 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { AppThemeProvider } from "@promentorapp/ui-kit";
+import { ToastContainer } from "react-toastify";
 import { QueryProvider } from "./app/providers/QueryProvider";
 import { App } from "./app";
+import "react-toastify/dist/ReactToastify.css";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
@@ -12,6 +14,7 @@ createRoot(document.getElementById("root")!).render(
       <QueryProvider>
         <BrowserRouter>
           <App />
+          <ToastContainer position="top-right" newestOnTop />
         </BrowserRouter>
       </QueryProvider>
     </AppThemeProvider>

--- a/apps/shell/src/shared/auth/authBridge.ts
+++ b/apps/shell/src/shared/auth/authBridge.ts
@@ -124,8 +124,8 @@ export const authBridge: AuthBridge = {
   },
   logout: async () => {
     try {
+      await authLogout().catch(() => undefined);
       if (queryClientRef) {
-        await authLogout().catch(() => undefined);
         queryClientRef.setQueryData(authQueryKeys.session(), null);
       }
     } finally {

--- a/apps/shell/src/shared/auth/authBridge.ts
+++ b/apps/shell/src/shared/auth/authBridge.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { User } from "@/entities/user/types";
+import { AUTH_LOGIN_REDIRECT_PATH } from "@/entities/user/model/constants";
 import { authQueryKeys } from "@/features/auth/api";
 import { authLogout } from "@/shared/api/generated/api";
 
@@ -122,14 +123,15 @@ export const authBridge: AuthBridge = {
     queryClientRef.setQueryData(authQueryKeys.session(), user);
   },
   logout: async () => {
-    if (!queryClientRef) {
-      throw new Error("Auth bridge is not initialized");
-    }
-
     try {
-      await authLogout();
+      if (queryClientRef) {
+        await authLogout().catch(() => undefined);
+        queryClientRef.setQueryData(authQueryKeys.session(), null);
+      }
     } finally {
-      queryClientRef.setQueryData(authQueryKeys.session(), null);
+      window.location.replace(
+        `${window.location.origin}${AUTH_LOGIN_REDIRECT_PATH}`,
+      );
     }
   },
 };

--- a/apps/shell/vite.config.ts
+++ b/apps/shell/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig(({ mode }) => {
   const coachingRemoteUrl =
     env.VITE_COACHING_REMOTE_URL ||
     "https://promentor-coaching.vercel.app/assets/remoteEntry.js";
+  const apiTarget = (env.VITE_API_URL || "http://localhost:3000").replace(
+    /\/$/,
+    "",
+  );
 
   return {
     optimizeDeps: {
@@ -32,7 +36,9 @@ export default defineConfig(({ mode }) => {
           "react",
           "react-dom",
           "react-router-dom",
+          "@tanstack/react-query",
           "@promentorapp/ui-kit",
+          "react-toastify",
         ],
       }),
     ],
@@ -45,6 +51,10 @@ export default defineConfig(({ mode }) => {
       port: 5173,
       strictPort: true,
       cors: true,
+      proxy: {
+        "/auth": { target: apiTarget, changeOrigin: true },
+        "/users": { target: apiTarget, changeOrigin: true },
+      },
     },
     preview: {
       port: 5173,

--- a/apps/shell/vite.config.ts
+++ b/apps/shell/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig(({ mode }) => {
       proxy: {
         "/auth": { target: apiTarget, changeOrigin: true },
         "/users": { target: apiTarget, changeOrigin: true },
+        "/rooms": { target: apiTarget, changeOrigin: true },
       },
     },
     preview: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@10.4.22)(rxjs@7.8.2)
       '@nestjs/throttler':
         specifier: ^6.4.0
-        version: 6.5.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+        version: 6.5.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)
       '@nestjs/websockets':
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -101,7 +101,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.7.3)
       '@nestjs/testing':
         specifier: ^10.4.22
-        version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22))
+        version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)
       '@types/cookie-parser':
         specifier: ^1.4.10
         version: 1.4.10(@types/express@5.0.6)
@@ -192,6 +192,9 @@ importers:
       react-router-dom:
         specifier: ^7.13.2
         version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-toastify:
+        specifier: ^11.0.5
+        version: 11.0.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -4806,6 +4809,12 @@ packages:
       react-dom:
         optional: true
 
+  react-toastify@11.0.5:
+    resolution: {integrity: sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -6861,7 +6870,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22))':
+  '@nestjs/testing@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -6869,7 +6878,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
 
-  '@nestjs/throttler@6.5.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+  '@nestjs/throttler@6.5.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -10961,6 +10970,12 @@ snapshots:
       react: 19.2.4
       set-cookie-parser: 2.7.2
     optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  react-toastify@11.0.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      clsx: 2.1.1
+      react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
   react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):


### PR DESCRIPTION
- Updated the Nest application setup to disable body parsing by default for better control over request handling.
- Integrated JSON and URL-encoded body parsing with a limit of 6mb in the HTTP app setup.
- Added support for `react-toastify` to manage toast notifications across the application.
- Updated user DTO validation to allow for a larger avatar URL size and improved error messaging.
- Enhanced e2e tests to reflect changes in application setup and validation messages.